### PR TITLE
Documentation from handoff sessions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,3 +23,11 @@
 1. User publishes the content
 1. Static CMS saves the published content in the main branch
 1. Netlify sees the published content and deploys it to the hosting behind `<url>`
+
+## Future Notes
+
+### CMS Branching
+
+Right now, Static CMS does not create a branch as diagrammed and instead just stores changes on the editor's computer until publishing. However, this feature is coming soon and can be upgraded in the future to do this. This will better enable previewing content before publishing.
+
+When that time comes, the version number in `@staticcms/app@^3.3.0` can be updated in [`src/admin/index.html][/src/admin/index.html].

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,13 +4,13 @@
 
 ## Code Parts
 
-- **Eleventy**: A JavaScript and Markdown based platform that generates static websites.
-- **Static CMS**: A content management systems that can read, write, and publish changes to a GitHub repository. It does not require an application server, but runs as a single page application hosted at the `/admin` endpoint. It uses GitHub as an authentication and authorization mechanism.
+- [**11ty**](https://www.11ty.dev/): A JavaScript and Markdown based platform that generates static websites.
+- [**Static CMS**](https://www.staticcms.org/): A content management systems that can read, write, and publish changes to a GitHub repository. It does not require an application server, but runs as a single page application hosted at the `/admin` endpoint. It uses GitHub as an authentication and authorization mechanism.
 
 ## Infrastructure 
 
-- **GitHub**: Store the application's code and is used to authenticate/authorize contributors.
-- **Netlify**: Hosts the application, including drafts and production deployments. Has a single user (but could have more if configured) that is linked to a GitHub account for access to the repository.
+- [**GitHub**](https://github.com/): Store the application's code and is used to authenticate/authorize contributors.
+- [**Netlify**](https://www.netlify.com/): Hosts the application, including drafts and production deployments. Has a single user (but could have more if configured) that is linked to a GitHub account for access to the repository.
 
 ## Publish Workflow
 
@@ -24,10 +24,24 @@
 1. Static CMS saves the published content in the main branch
 1. Netlify sees the published content and deploys it to the hosting behind `<url>`
 
-## Future Notes
+## Maintenance Notes
 
 ### CMS Branching
 
 Right now, Static CMS does not create a branch as diagrammed and instead just stores changes on the editor's computer until publishing. However, this feature is coming soon and can be upgraded in the future to do this. This will better enable previewing content before publishing.
 
 When that time comes, the version number in `@staticcms/app@^3.3.0` can be updated in [`src/admin/index.html][/src/admin/index.html].
+
+### Authentication and Authorization
+
+The site relies on the following mechanisms for authentication and authorization. Links to get to these settings are below and are accessible to CoramIT and other admin users (if any):
+
+- [**Netlify/GitHub Repo Writing**](https://github.com/coram-uk/coram-playbook/settings/installations): This allow Netlify to push branch deployment URLs to pull requests for preview deployments.
+- [**Netlify/GitHub Authentication and Authorization**](https://github.com/organizations/coram-uk/settings/installations): This enables users to login via Static CMS base by allowing Netlify to check if a user is within the Coram UK GitHub Organization.
+- [**GitHub User Authentication**](https://github.com/orgs/coram-uk/people): A user must be a member of the [Coram UK GitHub Organization](https://github.com/coram-uk) in order to authenticate via Static CMS.
+- [**GitHub User Authorization: Admins**](https://github.com/orgs/coram-uk/teams/coram-playbook-admins): A user in this team can modify settings in GitHub and also contribute content to the site.
+- [**GitHub User Authorization: Contributors**](https://github.com/orgs/coram-uk/teams/coram-playbook-contributors): A user in this team can contribute content to the site, but can't modify org/repo settings.
+
+### Domain Setup
+
+When the site's URLs need to be updated, the place to do that is within [Netlify's domain settings](https://app.netlify.com/teams/coram/dns). By adding a domain here, it'll provide the settings to add to your domain registration. Coram IT should be able to access these.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,33 @@
+# Editing Content
+
+There are a few ways to contribute content to the site.
+
+## Content Management System
+
+This is the easiest way to add, edit, remove content from the site for most users.
+
+### Setup / First Time
+
+1. [Create a GitHub account](https://github.com/signup)
+1. Verify your account email and [add two-factor authentication or a passkey](https://github.com/settings/security) 
+1. Request that Coram IT adds you to the [Coram Playbook Contributors Team](https://github.com/orgs/coram-uk/teams/coram-playbook-contributors) within the coram-uk GitHub Org.
+1. Navigate to [innovation.coram-i.org.uk/admin](https://innovation.coram-i.org.uk/admin) or [coram-playbook.netlify.app/admin](https://coram-playbook.netlify.app/admin) and sign-in with your GitHub account and authorize the application.
+
+### Contributing
+
+Once you're setup, you can edit content by going to [innovation.coram-i.org.uk/admin](https://innovation.coram-i.org.uk/admin) or [coram-playbook.netlify.app/admin](https://coram-playbook.netlify.app/admin).
+
+## Code
+
+For folks savvy at coding, an easier way to contribute might be through the code and GitHub directly. Steps are:
+
+1. Clone this repository
+1. Create a branch
+1. Make your changes
+1. Submit a pull request (which will trigger a preview to test your changes in the PR itself)
+1. Either ask someone to review or merge it.
+
+Content is located in the following locations:
+
+- `/src/_data`: Text content
+- `/src/images`: Picture content


### PR DESCRIPTION
Added a few items of documentation based on our handoff sessions last week:

- Links to infrastructure components
- How authentication and authorization happens, with links to where to modify settings
- Instructions on how to contribute to the site, with links to the CMS